### PR TITLE
helix-aac: add MACRO for PNS feature to disable MPEG4 support

### DIFF
--- a/aaccommon.h
+++ b/aaccommon.h
@@ -49,6 +49,10 @@
 #include "Arduino.h"
 //#include <pgmspace.h>
 
+#ifdef CONFIG_LIB_HELIX_AAC_PNS
+  #define AAC_ENABLE_PNS 1
+#endif
+
 #ifdef CONFIG_LIB_HELIX_AAC_SBR
   #define AAC_ENABLE_SBR 1
 #endif

--- a/pns.c
+++ b/pns.c
@@ -46,6 +46,8 @@
 #include "coder.h"
 #include "assembly.h"
 
+#ifdef AAC_ENABLE_PNS
+
 /**************************************************************************************
  * Function:    Get32BitVal
  *
@@ -363,3 +365,15 @@ int PNS(AACDecInfo *aacDecInfo, int ch)
 	
 	return 0;
 }
+
+#else
+
+int PNS(AACDecInfo *aacDecInfo, int ch)
+{
+    if (aacDecInfo->pnsUsed)
+        return ERR_AAC_PNS;
+    else
+        return ERR_AAC_NONE;
+}
+
+#endif


### PR DESCRIPTION

## Summary

helix-aac: add MACRO for PNS feature to disable MPEG4 support


## Impact

helix-aac


## Testing

aac decder

